### PR TITLE
Update dotfiles URL to new repository

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ tasks:
     command: |
       if [ ! -d "~/.dotfiles" ]; then
         cd /tmp
-        curl -sSL https://raw.githubusercontent.com/gbraad/dotfiles/master/install.sh -o /tmp/install.sh &&
+        curl -sSL https://raw.githubusercontent.com/gbraad-dotfiles/upstream/master/install.sh -o /tmp/install.sh &&
         rm -f ~/.zshrc &&
         sh /tmp/install.sh
       fi

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage
   * Open in [Gitpod workspace](https://gitpod.io/#https://github.com/gbraad-devenv/fedora)
   * Open in [GitHub Codespaces](https://codespaces.new/gbraad-devenv/fedora)
   * Open in [CodeSandbox](https://codesandbox.io/p/github/gbraad-devenv/fedora)
-  * `dev fed env`, `dev fed sys` in [my dotfiles](https://github.com/gbraad/dotfiles/blob/main/zsh/.zshrc.d/devenv.zsh)
+  * `dev fed env`, `dev fed sys` in [my dotfiles](https://github.com/gbraad-dotfiles/upstream/blob/main/zsh/.zshrc.d/devenv.zsh)
   * Toobox/distrobox using `ghcr.io/gbraad-devenv/fedora/toolbox:41`
 
 
@@ -32,7 +32,7 @@ $ podman run -it --cap-add=NET_ADMIN --cap-add=NET_RAW --device=/dev/net/tun ghc
 ```
 
 > [!NOTE]
-> For more information about the [container](docs/podman.md) build and usage in [my dotfiles](https://github.com/gbraad/dotfiles/blob/main/zsh/.zshrc.d/devenv.zsh)
+> For more information about the [container](docs/podman.md) build and usage in [my dotfiles](https://github.com/gbraad-dotfiles/upstream/blob/main/zsh/.zshrc.d/devenv.zsh)
 
 
 ### Devbox

--- a/containers/Containerfile-base
+++ b/containers/Containerfile-base
@@ -84,6 +84,6 @@ RUN dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/r
     && rm -rf /var/cache/yum
 
 # dotfiles for root
-RUN git clone https://github.com/gbraad/dotfiles ~/.dotfiles \
+RUN git clone https://github.com/gbraad-dotfiles/upstream ~/.dotfiles \
     && ~/.dotfiles/install.sh \
     && chsh root -s /bin/zsh

--- a/containers/Containerfile-dotfiles
+++ b/containers/Containerfile-dotfiles
@@ -17,7 +17,7 @@ RUN useradd -l -u 1000 -G users,wheel -md /var/home/gbraad -s /bin/bash -p gbraa
 USER gbraad
 
 RUN rm -f ~/.zshrc \
-    && git clone https://github.com/gbraad/dotfiles ~/.dotfiles \
+    && git clone https://github.com/gbraad-dotfiles/upstream ~/.dotfiles \
     && ~/.dotfiles/install.sh \
     && sudo chsh gbraad -s /bin/zsh
 


### PR DESCRIPTION
Update repository references from `github.com/gbraad/dotfiles` to `github.com/gbraad-dotfiles/upstream`.

* **README.md**
  - Update the link to `my dotfiles` to `https://github.com/gbraad-dotfiles/upstream/blob/main/zsh/.zshrc.d/devenv.zsh`.
  - Update the note section link to `https://github.com/gbraad-dotfiles/upstream/blob/main/zsh/.zshrc.d/devenv.zsh`.

* **containers/Containerfile-base**
  - Update the `RUN` command to clone `https://github.com/gbraad-dotfiles/upstream` instead of `https://github.com/gbraad/dotfiles`.

* **containers/Containerfile-dotfiles**
  - Update the `RUN` command to clone `https://github.com/gbraad-dotfiles/upstream` instead of `https://github.com/gbraad/dotfiles`.

* **.gitpod.yml**
  - Update the `dotfiles` task to use `https://raw.githubusercontent.com/gbraad-dotfiles/upstream/master/install.sh` instead of `https://raw.githubusercontent.com/gbraad/dotfiles/master/install.sh`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gbraad-devenv/fedora/pull/73?shareId=d3e88b6a-1933-404a-a53f-2233432d79a1).